### PR TITLE
adding csrf field.

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -1,0 +1,46 @@
+package partial
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+var (
+	DefaultCsrfToken = "X-CSRF-Token"
+)
+
+type CsrfToken interface {
+	Token(ctx context.Context) string
+	Key() string
+}
+
+func getCsrfToken(ctx context.Context) CsrfToken {
+	if csrfer, ok := ctx.Value(DefaultCsrfToken).(CsrfToken); ok {
+		return csrfer
+	}
+
+	timeToken := time.Now().UnixNano()
+
+	return &defaultCsrf{
+		token: fmt.Sprintf("invalid-token-%d", timeToken),
+		key:   DefaultCsrfToken,
+	}
+}
+
+type defaultCsrf struct {
+	token string
+	key   string
+}
+
+func (d *defaultCsrf) Token(ctx context.Context) string {
+	if token, ok := ctx.Value(DefaultCsrfToken).(string); ok {
+		return token
+	}
+
+	return d.token
+}
+
+func (d *defaultCsrf) Key() string {
+	return d.key
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/partial-coffee/go-partial
 
-go 1.23.2
-
-require github.com/donseba/go-partial v0.8.0
+go 1.24

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/donseba/go-partial v0.8.0 h1:Dl2oQjUNS/yFt2oh2JwwiGj75h7tL+C/Qck0EMLzzk8=
-github.com/donseba/go-partial v0.8.0/go.mod h1:YKb5pjaarArKA00Hn/GrlamWZOReRzZ4TO8cjoJhyEw=

--- a/partial.go
+++ b/partial.go
@@ -94,6 +94,8 @@ type (
 		Layout map[string]any
 		// Loc contains the localizer
 		Loc Localizer
+		// Csrf contains the CSRF token
+		Csrf CsrfToken
 	}
 
 	// GlobalData represents the global data available to all partials.
@@ -708,6 +710,7 @@ func (p *Partial) renderSelf(ctx context.Context, r *http.Request) (template.HTM
 		Service: p.getGlobalData(),
 		Layout:  p.getLayoutData(),
 		Loc:     getLocalizer(ctx),
+		Csrf:    getCsrfToken(ctx),
 	}
 
 	if p.action != nil {


### PR DESCRIPTION
This pull request introduces CSRF token handling to the `partial` package and updates the Go version in the `go.mod` file. The most important changes include adding a new interface and implementation for CSRF tokens, updating the context to include CSRF tokens, and adding tests for the new functionality.

### CSRF Token Handling:

* [`csrf.go`](diffhunk://#diff-91f15a25e5475edc420ef0da93a2a747c2d34e0c05767b50a72f9754c2c32b5cR1-R46): Added a new `CsrfToken` interface and its implementation, along with a function to retrieve the CSRF token from the context.
* [`partial.go`](diffhunk://#diff-3eed553bcb7bc0c8764dc4d26cef81629b4968bebfc55d22e840fc7efd3f1071R97-R98): Updated the `type` definition to include a new `Csrf` field and modified the `renderSelf` method to retrieve the CSRF token from the context. [[1]](diffhunk://#diff-3eed553bcb7bc0c8764dc4d26cef81629b4968bebfc55d22e840fc7efd3f1071R97-R98) [[2]](diffhunk://#diff-3eed553bcb7bc0c8764dc4d26cef81629b4968bebfc55d22e840fc7efd3f1071R713)

### Go Version Update:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from 1.23.2 to 1.24.

### Tests:

* [`partial_test.go`](diffhunk://#diff-3edb86cfe170624616cdd5b04903b077fb4cfea8e4f5dc1ab5e967e20fc6b049R723-R826): Added tests for the new CSRF token functionality, including basic token retrieval and context-based token setting.