### PR TITLE
fix basepath and fix global data

### DIFF
--- a/partial_test.go
+++ b/partial_test.go
@@ -124,7 +124,7 @@ func TestWithGlobalData(t *testing.T) {
 		}
 
 		p := New("templates/index.html").ID("root")
-		p.SetGlobalData(map[string]any{
+		p.SetData(map[string]any{
 			"Text": "Welcome to the home page",
 		})
 
@@ -863,4 +863,24 @@ func TestDefaultCsrf_Key(t *testing.T) {
 			t.Errorf("expected %s, got %s", expected, response.Body.String())
 		}
 	})
+}
+
+func TestGetGlobalDataRecursive(t *testing.T) {
+	root := New()
+	root.SetData(map[string]any{"a": 1, "b": 2})
+
+	child := New()
+	child.SetData(map[string]any{"b": 3, "c": 4})
+	child.SetParent(root)
+
+	grandchild := New()
+	grandchild.SetData(map[string]any{"c": 5, "d": 6})
+	grandchild.SetParent(child)
+
+	child.With(grandchild)
+	root.With(child)
+
+	if len(grandchild.getGlobalData()) != 3 {
+		t.Errorf("expected 3 results")
+	}
 }


### PR DESCRIPTION
This pull request refactors the `Partial` class in `partial.go` to improve data handling and introduces new methods for better functionality. Key changes include deprecating the `SetGlobalData` method, adding recursive data merging capabilities, and updating tests to reflect the new behavior.

### Refactoring and Deprecation:

* [`partial.go`](diffhunk://#diff-3eed553bcb7bc0c8764dc4d26cef81629b4968bebfc55d22e840fc7efd3f1071L274-R275): Deprecated the `SetGlobalData` method in favor of `SetData` for setting global data.

### Recursive Data Handling:

* [`partial.go`](diffhunk://#diff-3eed553bcb7bc0c8764dc4d26cef81629b4968bebfc55d22e840fc7efd3f1071R534-R557): Added `getGlobalDataMergedWithOwn` method to recursively merge parent and child global data. Updated `getGlobalData` to use this new method.
* [`partial.go`](diffhunk://#diff-3eed553bcb7bc0c8764dc4d26cef81629b4968bebfc55d22e840fc7efd3f1071R580-R586): Introduced `getBasePath` method to retrieve the base path recursively from parent instances. Updated `renderSelf` to use this method. [[1]](diffhunk://#diff-3eed553bcb7bc0c8764dc4d26cef81629b4968bebfc55d22e840fc7efd3f1071R580-R586) [[2]](diffhunk://#diff-3eed553bcb7bc0c8764dc4d26cef81629b4968bebfc55d22e840fc7efd3f1071L750-R771)

### Test Updates:

* [`partial_test.go`](diffhunk://#diff-3edb86cfe170624616cdd5b04903b077fb4cfea8e4f5dc1ab5e967e20fc6b049L127-R127): Updated tests to use the new `SetData` method instead of the deprecated `SetGlobalData`.
* [`partial_test.go`](diffhunk://#diff-3edb86cfe170624616cdd5b04903b077fb4cfea8e4f5dc1ab5e967e20fc6b049R867-R886): Added `TestGetGlobalDataRecursive` to validate recursive global data merging across parent-child relationships.