### PR TITLE
basepath second fix

### DIFF
--- a/partial.go
+++ b/partial.go
@@ -579,8 +579,12 @@ func (p *Partial) getServiceData() map[string]any {
 
 func (p *Partial) getBasePath() string {
 	if p.parent != nil {
-		return p.parent.getBasePath()
+		bp := p.parent.getBasePath()
+		if bp != "" {
+			return bp
+		}
 	}
+
 	return p.basePath
 }
 


### PR DESCRIPTION
This pull request includes a minor update to the `getBasePath` method in `partial.go`. The change introduces a conditional check to ensure that the base path returned from the parent is not an empty string before using it.